### PR TITLE
[feat][style] 게시판 관련 페이지 및 컴포넌트 스타일 수정 및 기능 추가

### DIFF
--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -3,6 +3,8 @@ import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Home from './pages/Home/Home';
 import DevBoard from './pages/DevBoard/DevBoard';
+import PostDetail from './pages/DevBoard/PostDetail';
+
 
 function App() {
   return (
@@ -10,6 +12,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/dev-board" element={<DevBoard />} />
+        <Route path="/dev-board/:postId" element={<PostDetail />} />
       </Routes>
     </Router>
   )

--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -2,12 +2,14 @@ import './App.css'
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Home from './pages/Home/Home';
+import DevBoard from './pages/DevBoard/DevBoard';
 
 function App() {
   return (
     <Router>
       <Routes>
         <Route path="/" element={<Home />} />
+        <Route path="/dev-board" element={<DevBoard />} />
       </Routes>
     </Router>
   )

--- a/front/src/components/layout/NavigationBar.jsx
+++ b/front/src/components/layout/NavigationBar.jsx
@@ -1,0 +1,102 @@
+import React from "react";
+import styled from "styled-components";
+import {COLORS} from "../../constants/colors";
+import {useNavigate, useLocation} from "react-router-dom";
+
+const Container = styled.div`
+    width: 100%;
+    height: 70px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 20px;
+    background-color: white;
+    box-shadow: 0 0 4px rgba(0, 0, 0, 0.1);
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 1000;
+`;
+
+const Logo = styled.div`
+    font-size: 24px;
+    font-weight: bold;
+    cursor: pointer;
+    color: ${COLORS.sig};
+`;
+
+const MenuContainer = styled.div`
+    display: flex;
+
+`;
+
+const MenuButton = styled.div`
+    padding: 8px 16px;
+    cursor: pointer;
+    color: ${props => props.isActive ? COLORS.sig : 'gray'};
+    position: relative;
+    
+    div {
+        display: inline-block;
+        transform: ${props => props.isActive ? 'scale(1.1)' : 'scale(1)'};
+        transition: 0.3s;
+        &:hover {
+            transform: scale(1.1);
+            color: ${COLORS.sig};
+        }
+    }
+
+    &:not(:last-child)::after {
+        content: '';
+        position: absolute;
+        right: 0;
+        top: 50%;
+        transform: translateY(-50%);
+        height: 15px;
+        width: 1px;
+        background-color: #e0e0e0;
+    }
+`;
+
+const LoginButton = styled.div`
+    padding: 8px 20px;
+    border: 2px solid ${COLORS.sig};
+    border-radius: 20px;
+    color: white;
+    background-color: ${COLORS.sig};
+    cursor: pointer;
+    margin-right: 40px;
+    &:hover {
+        transform: scale(1.05);
+        transition: 0.3s;
+        background-color: white;
+        color: ${COLORS.sig};
+    }
+`;
+
+export default function NavigationBar() {
+    const navigate = useNavigate();
+    const location = useLocation();
+    
+    //클릭 시 어디로 갈지 url 지정. 컨퍼런스 페이지와 마이페이지 페이지 추가해야함.
+    return (
+        <Container>
+            <Logo onClick={() => navigate("/")}>DevConf</Logo>
+            <MenuContainer>
+                <MenuButton isActive={location.pathname === "/"} onClick={() => navigate("/")}>
+                    <div>메인화면</div>
+                </MenuButton>
+                <MenuButton isActive={location.pathname === "/conference"}>
+                    <div>컨퍼런스 일정</div>
+                </MenuButton> 
+                <MenuButton isActive={location.pathname === "/dev-board"} onClick={() => navigate("/dev-board")}>
+                    <div>게시판</div>
+                </MenuButton>
+                <MenuButton isActive={location.pathname === "/mypage"}>
+                    <div>마이페이지</div>
+                </MenuButton>
+            </MenuContainer>
+            <LoginButton>로그인</LoginButton>
+        </Container>
+    )
+}

--- a/front/src/components/layout/NavigationBar.jsx
+++ b/front/src/components/layout/NavigationBar.jsx
@@ -11,7 +11,7 @@ const Container = styled.div`
     justify-content: space-between;
     padding: 0 20px;
     background-color: white;
-    box-shadow: 0 0 4px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
     position: fixed;
     top: 0;
     left: 0;
@@ -84,16 +84,16 @@ export default function NavigationBar() {
             <Logo onClick={() => navigate("/")}>DevConf</Logo>
             <MenuContainer>
                 <MenuButton isActive={location.pathname === "/"} onClick={() => navigate("/")}>
-                    <div>메인화면</div>
+                    <div>메인 화면</div>
                 </MenuButton>
-                <MenuButton isActive={location.pathname === "/conference"}>
+                <MenuButton isActive={location.pathname === "/conference"} onClick={() => navigate("/conference")}>
                     <div>컨퍼런스 일정</div>
                 </MenuButton> 
                 <MenuButton isActive={location.pathname === "/dev-board"} onClick={() => navigate("/dev-board")}>
                     <div>게시판</div>
                 </MenuButton>
-                <MenuButton isActive={location.pathname === "/mypage"}>
-                    <div>마이페이지</div>
+                <MenuButton isActive={location.pathname === "/mypage"} onClick={() => navigate("/mypage")}>
+                    <div>마이 페이지</div>
                 </MenuButton>
             </MenuContainer>
             <LoginButton>로그인</LoginButton>

--- a/front/src/constants/colors.js
+++ b/front/src/constants/colors.js
@@ -1,3 +1,4 @@
 export const COLORS = {
   sig: "#5D5A88",
+  bg: "#F2F1FA"
 };

--- a/front/src/pages/DevBoard/DevBoard.jsx
+++ b/front/src/pages/DevBoard/DevBoard.jsx
@@ -1,0 +1,223 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { COLORS } from "../../constants/colors";
+import WritePost from "./WritePost";
+import { useNavigate } from "react-router-dom";
+import NavigationBar from "../../components/layout/NavigationBar"; 
+
+const BoardContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 80px;  // 네비게이션 바 높이(70px) + 여유 공간을 고려하여 수정
+  min-height: 100vh;  
+  position: relative;  
+
+  h1 {
+    color: ${COLORS.sig};
+    margin-bottom: 50px; 
+  }
+`;
+
+const PostsWrapper = styled.div`
+  width: 80%;
+  max-width: 800px;
+  position: relative;
+  padding-bottom: 100px; 
+`;
+
+const PostItem = styled.div`
+  padding: 20px;
+  margin: 10px 0;
+  border: 1px solid #ddd;
+  border-radius: 20px;
+  width: 100%;
+  cursor: pointer;
+  transition: all 0.4s ease;
+  overflow: hidden;
+
+  &:hover {
+    background-color: ${COLORS.bg};
+    padding: 80px 20px;
+    transform: scale(1.03);
+    box-shadow: 0 8px 16px rgba(93, 90, 136, 0.2);
+    margin: 5px 0;
+  }
+`;
+
+const WriteButton = styled.button`
+  padding: 8px 18px;
+  background-color: ${COLORS.sig};
+  color: white;
+  border: none;
+  border-radius: 25px;
+  cursor: pointer;
+  position: absolute;
+  right: -45px;
+  top: -40px;
+  font-size: 15px;
+  transition: background-color 0.2s;
+
+  &:hover {
+    transform: scale(1.1);
+    transition: all 0.3s;
+  }
+`;
+
+const SortButton = styled.button`
+  padding: 12px 24px;
+  background-color: transparent;
+  color: gray;  
+  border: none;
+  cursor: pointer;
+  position: absolute;
+  left: 0;
+  top: -25px;
+  font-size: 15px;
+  transition: color 0.2s;
+
+  &:hover {
+    color: ${COLORS.sig};
+    transform: scale(1.1);
+    transition: 0.1s;
+  }
+`;
+
+const PostContent = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+`;
+
+const PostTitle = styled.h3`
+  margin: 0;
+  color: ${COLORS.sig};
+`;
+
+const PostInfo = styled.p`
+  margin: 0;
+  color: ${COLORS.sig};
+`;
+
+const PaginationWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  position: fixed;
+  bottom: 30px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: white;
+  padding: 15px;
+  box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);
+  border-radius: 20px;
+
+`;
+
+const PageButton = styled.button`
+  padding: 8px 12px;
+  border: 1px solid ${COLORS.sig};
+  background-color: ${props => props.active ? COLORS.sig : 'white'};
+  color: ${props => props.active ? 'white' : COLORS.sig};
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    background-color: #4d4a73;
+    color: white;
+    transform: scale(1.2);
+    transition: all 0.3s;
+  }
+`;
+
+export default function DevBoard() {
+  const navigate = useNavigate();
+  const [currentPage, setCurrentPage] = useState(1);
+  const [sortOrder, setSortOrder] = useState('desc'); 
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const postsPerPage = 7;
+  
+  const posts = [
+    { id: 1, title: "1 번째 게시글", name: "가나다", date: "2024-01-01" },
+    { id: 2, title: "2 번째 게시글", name: "라마바", date: "2024-01-02" },
+    { id: 3, title: "3 번째 게시글", name: "사아자", date: "2024-01-03" },
+    { id: 4, title: "4 번째 게시글", name: "차카타", date: "2024-01-04" },
+    { id: 5, title: "5 번째 게시글", name: "파하파", date: "2024-01-05" },
+    { id: 6, title: "6 번째 게시글", name: "홍길동", date: "2024-01-06" },
+    { id: 7, title: "7 번째 게시글🥲", name: "김철수", date: "2024-01-07" },
+    { id: 8, title: "8 번째 게시글", name: "가나다", date: "2024-01-08" },
+    { id: 9, title: "9 번째 게시글", name: "라마바", date: "2024-01-09" },
+    { id: 10, title: "10 번째 게시글", name: "사아자", date: "2024-01-10" },
+    { id: 11, title: "11 번째 게시글", name: "차카타", date: "2024-01-11" },
+    { id: 12, title: "12 번째 게시글", name: "파하파", date: "2024-01-12" },
+    { id: 13, title: "13 번째 게시글", name: "홍길동", date: "2024-01-13" },
+    { id: 14, title: "14 번째 게시글🥲", name: "김철수", date: "2024-01-14" },
+    { id: 15, title: "15 번째 게시글", name: "가나다", date: "2024-01-15" },
+    { id: 16, title: "16 번째 게시글", name: "라마바", date: "2024-01-16" },
+    { id: 17, title: "17 번째 게시글", name: "사아자", date: "2024-01-17" },
+    { id: 18, title: "18 번째 게시글", name: "차카타", date: "2024-01-18" },
+    { id: 19, title: "19 번째 게시글", name: "파하파", date: "2024-01-19" },
+    { id: 20, title: "20 번째 게시글", name: "홍길동", date: "2024-01-20" },
+    { id: 21, title: "21 번째 게시글🥲", name: "김철수", date: "2024-01-21" },
+  ];
+
+  // 정렬된 게시글 목록 생성
+  const sortedPosts = [...posts].sort((a, b) => {
+    if (sortOrder === 'desc') {
+      return new Date(b.date) - new Date(a.date);
+    } else {
+      return new Date(a.date) - new Date(b.date);
+    }
+  });
+
+  const indexOfLastPost = currentPage * postsPerPage;
+  const indexOfFirstPost = indexOfLastPost - postsPerPage;
+  const currentPosts = sortedPosts.slice(indexOfFirstPost, indexOfLastPost);
+  const totalPages = Math.ceil(posts.length / postsPerPage);
+
+  const pageNumbers = [];
+  for (let i = 1; i <= totalPages; i++) {
+    pageNumbers.push(i);
+  }
+
+  const handlePostClick = (postId) => {
+    navigate(`/dev-board/${postId}`);
+  };
+
+  return (
+    <>
+      <NavigationBar />
+      <BoardContainer>
+        <h1>게시판</h1>
+        <PostsWrapper>
+          <SortButton onClick={() => setSortOrder(sortOrder === 'desc' ? 'asc' : 'desc')}>
+            {sortOrder === 'desc' ? '최신순' : '오래된순'}
+          </SortButton>
+          <WriteButton onClick={() => setIsModalOpen(true)}>📝 글쓰기</WriteButton>
+          {currentPosts.map(post => (
+            <PostItem key={post.id} onClick={() => handlePostClick(post.id)}>
+              <PostContent>
+                <PostTitle>{post.title}</PostTitle>
+                <PostInfo>작성자: {post.name} | 작성일: {post.date}</PostInfo>
+              </PostContent>
+            </PostItem>
+          ))}
+          <PaginationWrapper>
+            {pageNumbers.map(number => (
+              <PageButton
+                key={number}
+                active={currentPage === number}
+                onClick={() => setCurrentPage(number)}
+              >
+                {number}
+              </PageButton>
+            ))}
+          </PaginationWrapper>
+        </PostsWrapper>
+      </BoardContainer>
+      {isModalOpen && <WritePost onClose={() => setIsModalOpen(false)} />}
+    </>
+  );
+}

--- a/front/src/pages/DevBoard/DevBoard.jsx
+++ b/front/src/pages/DevBoard/DevBoard.jsx
@@ -110,7 +110,7 @@ const PaginationWrapper = styled.div`
   transform: translateX(-50%);
   background-color: white;
   padding: 15px;
-  box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.2);
   border-radius: 20px;
 
 `;
@@ -139,6 +139,7 @@ export default function DevBoard() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const postsPerPage = 7;
   
+  // 더미 데이터(나중에 API 연동으로 대체)
   const posts = [
     { id: 1, title: "1 번째 게시글", name: "가나다", date: "2024-01-01" },
     { id: 2, title: "2 번째 게시글", name: "라마바", date: "2024-01-02" },

--- a/front/src/pages/DevBoard/PostDetail.jsx
+++ b/front/src/pages/DevBoard/PostDetail.jsx
@@ -1,0 +1,191 @@
+import React from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import styled from "styled-components";
+import { COLORS } from "../../constants/colors";
+import NavigationBar from "../../components/layout/NavigationBar";  // 추가
+
+const MainContainer = styled.div`
+  border: 3px solid ${COLORS.bg};
+  border-radius: 20px;
+  margin: 100px auto;
+  max-width: 1200px;
+`;
+
+const DetailContainer = styled.div`
+  max-width: 1200px;
+  margin: 20px;
+  padding: 20px;
+`;
+
+const PostHeader = styled.div`
+`;
+
+const Title = styled.h1`
+  color: ${COLORS.sig};
+  margin-bottom: 10px;
+`;
+
+const PostInfo = styled.div`
+  color: gray;
+  font-size: 0.9rem;
+`;
+
+const Content = styled.div`
+  margin-top: 10px;
+  line-height: 1.6;
+  border: 3px solid ${COLORS.bg};
+  border-radius:20px;
+  padding: 0 0 300px 0;
+
+  div {
+    padding: 10px;
+  }
+`;
+
+const BackButton = styled.button`
+  padding: 8px 16px;
+  background-color: ${COLORS.sig};
+  color: white;
+  border: none;
+  border-radius: 20px;
+  cursor: pointer;
+  margin-bottom: 20px;
+
+  &:hover {
+    transform: scale(1.05);
+    transition: all 0.2s;
+  }
+`;
+
+const CommentSection = styled.div`
+  margin-top: 30px;
+  h3 {
+  color: ${COLORS.sig};
+  }
+`;
+
+const CommentInputSection = styled.div`
+  border-bottom: 3px solid ${COLORS.bg};
+  padding-bottom: 20px;
+`;
+const CommentForm = styled.form`
+  margin: 20px 0;
+`;
+
+const CommentInput = styled.textarea`
+  width: 97.7%;
+  padding: 10px;
+  border: 2px solid ${COLORS.bg};
+  border-radius: 10px;
+  margin-bottom: 10px;
+  resize: vertical;
+  min-height: 80px;
+  background-color: ${COLORS.bg};
+`;
+
+const CommentButton = styled.button`
+  padding: 8px 16px;
+  background-color: ${COLORS.sig};
+  color: white;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  float: right;
+`;
+
+const CommentList = styled.div`
+  margin-top: 40px;
+
+`;
+
+const CommentItem = styled.div`
+  border: 1px solid ${COLORS.bg};
+  border-radius: 15px;
+  padding: 15px 0;
+  margin-bottom: 20px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+
+  div{
+    padding: 1px;
+    margin-left: 10px;
+  }
+`;
+
+const CommentInfo = styled.div`
+  font-size: 0.9rem;
+  color: gray;
+  margin-bottom: 5px;
+  color: ${COLORS.sig};
+`;
+
+export default function PostDetail() {
+  const { postId } = useParams();
+  const navigate = useNavigate();
+
+  // 더미 데이터 (나중에 API로 대체...json 데이터)
+  const post = {
+    id: postId,
+    title: "게시글 제목",
+    content: "게시글 내용",
+    name: "작성자",
+    date: "2024-01-15"
+  };
+
+  // 더미 댓글 데이터
+  const comments = [
+    { id: 1, name: "홍길동", content: "좋은 글이네요!", date: "2024-01-16" },
+    { id: 2, name: "김철수", content: "감사합니다.", date: "2024-01-16" },
+    { id: 2, name: "김철수", content: "감사합니다.", date: "2024-01-16" },
+    { id: 2, name: "김철수", content: "감사합니다.", date: "2024-01-16" },
+    { id: 2, name: "김철수", content: "감사합니다.", date: "2024-01-16" },
+    { id: 2, name: "김철수", content: "감사합니다.", date: "2024-01-16" },
+    { id: 2, name: "김철수", content: "감사합니다.", date: "2024-01-16" },
+  ];
+
+  const handleCommentSubmit = (e) => {
+    e.preventDefault();
+    // 댓글 제출 로직 구현 예정
+  };
+
+  return (
+    <>
+      <NavigationBar />
+      <MainContainer>
+        <DetailContainer>
+          <BackButton onClick={() => navigate('/dev-board')}>← 목록으로</BackButton>
+          <PostHeader>
+            <Title>{post.title}</Title>
+            <PostInfo>
+              작성자: {post.name} | 작성일: {post.date}
+            </PostInfo>
+          </PostHeader>
+          <Content>
+            <div>{post.content}</div>
+          </Content>
+          
+          <CommentSection>
+            <h3>댓글</h3>
+            <CommentInputSection>
+            <CommentForm onSubmit={handleCommentSubmit}>
+              <CommentInput placeholder="댓글을 입력하세요" />
+              <CommentButton type="submit">등록</CommentButton>
+            </CommentForm>
+            </CommentInputSection>
+            
+            <CommentList>
+              {comments.map((comment) => (
+                <CommentItem key={comment.id}>
+                  <CommentInfo>
+                    {comment.name} | {comment.date}
+                  </CommentInfo>
+                  <div>{comment.content}</div>
+                </CommentItem>
+              ))}
+            </CommentList>
+          </CommentSection>
+          
+        </DetailContainer>
+      </MainContainer>
+    </>
+  );
+}

--- a/front/src/pages/DevBoard/PostDetail.jsx
+++ b/front/src/pages/DevBoard/PostDetail.jsx
@@ -5,10 +5,12 @@ import { COLORS } from "../../constants/colors";
 import NavigationBar from "../../components/layout/NavigationBar";  // 추가
 
 const MainContainer = styled.div`
-  border: 3px solid ${COLORS.bg};
+  border: 1px solid ${COLORS.bg};
   border-radius: 20px;
   margin: 100px auto;
   max-width: 1200px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+
 `;
 
 const DetailContainer = styled.div`
@@ -33,9 +35,10 @@ const PostInfo = styled.div`
 const Content = styled.div`
   margin-top: 10px;
   line-height: 1.6;
-  border: 3px solid ${COLORS.bg};
+  border: 1px solid ${COLORS.bg};
   border-radius:20px;
-  padding: 0 0 300px 0;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  min-height: 300px;
 
   div {
     padding: 10px;
@@ -75,12 +78,18 @@ const CommentForm = styled.form`
 const CommentInput = styled.textarea`
   width: 97.7%;
   padding: 10px;
-  border: 2px solid ${COLORS.bg};
+  border: 1px solid ${COLORS.bg};
   border-radius: 10px;
   margin-bottom: 10px;
   resize: vertical;
   min-height: 80px;
   background-color: ${COLORS.bg};
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+
+  &:focus {
+    outline: none;
+    border-color: ${COLORS.sig};
+  }
 `;
 
 const CommentButton = styled.button`
@@ -88,9 +97,14 @@ const CommentButton = styled.button`
   background-color: ${COLORS.sig};
   color: white;
   border: none;
-  border-radius: 10px;
+  border-radius: 20px;
   cursor: pointer;
   float: right;
+
+  &:hover {
+    transform: scale(1.05);
+    transition: all 0.2s;
+  }
 `;
 
 const CommentList = styled.div`
@@ -126,7 +140,7 @@ export default function PostDetail() {
   const post = {
     id: postId,
     title: "게시글 제목",
-    content: "게시글 내용",
+    content: "게시글 내용👍",
     name: "작성자",
     date: "2024-01-15"
   };

--- a/front/src/pages/DevBoard/WritePost.jsx
+++ b/front/src/pages/DevBoard/WritePost.jsx
@@ -1,0 +1,121 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { COLORS } from '../../constants/colors';
+
+const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0,0,0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+`;
+
+const ModalContent = styled.div`
+  background-color: white;
+  padding: 30px;
+  border-radius: 20px;
+  width: 80%;
+  height: 70%;
+  max-width: 700px;
+  max-height: 700px;
+
+`;
+
+const Title = styled.h2`
+  color: ${COLORS.sig};
+  margin-bottom: 20px;
+`;
+
+const Input = styled.input`
+  width: 96%;
+  padding: 12px;
+  margin-bottom: 20px;
+  border: 1px solid #ddd;
+  border-radius: 15px;
+  font-size: 16px;
+  background-color: ${COLORS.bg};
+`;
+const TextArea = styled.textarea`
+  width: 96%;
+  height: 400px;
+  padding: 12px;
+  margin-bottom: 20px;
+  border: 1px solid #ddd;
+  border-radius: 15px;
+  font-size: 16px;
+  resize: vertical;
+  background-color: ${COLORS.bg};
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+`;
+
+const Button = styled.button`
+  padding: 10px 20px;
+  border-radius: 20px;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+`;
+
+const CancelButton = styled(Button)`
+  background-color: white;
+  color: ${COLORS.sig};
+  border: 1px solid ${COLORS.sig};
+  &:hover {
+    transform: scale(1.2);
+    transition: all 0.3s;
+  }
+`;
+
+const SubmitButton = styled(Button)`
+  background-color: ${COLORS.sig};
+  color: white;
+ border: 1px solid ${COLORS.sig};
+
+  &:hover {
+    transform: scale(1.2);
+    transition: all 0.3s;
+  }
+`;
+
+export default function WritePost({ onClose }) {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+
+  const handleSubmit = () => {
+    // TODO: 게시글 등록 로직 구현
+    console.log({ title, content });
+    onClose();
+  };
+
+  return (
+    <ModalOverlay onClick={onClose}>
+      <ModalContent onClick={e => e.stopPropagation()}>
+        <Title>📝 게시글 작성</Title>
+        <Input
+          placeholder="제목을 입력하세요"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+        />
+        <TextArea
+          placeholder="내용을 입력하세요"
+          value={content}
+          onChange={e => setContent(e.target.value)}
+        />
+        <ButtonContainer>
+          <CancelButton onClick={onClose}>취소</CancelButton>
+          <SubmitButton onClick={handleSubmit}>등록</SubmitButton>
+        </ButtonContainer>
+      </ModalContent>
+    </ModalOverlay>
+  );
+}

--- a/front/src/pages/DevBoard/WritePost.jsx
+++ b/front/src/pages/DevBoard/WritePost.jsx
@@ -39,7 +39,14 @@ const Input = styled.input`
   border-radius: 15px;
   font-size: 16px;
   background-color: ${COLORS.bg};
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+
+  &:focus {
+    outline: none;
+    border-color: ${COLORS.sig};
+  }
 `;
+
 const TextArea = styled.textarea`
   width: 96%;
   height: 400px;
@@ -50,6 +57,12 @@ const TextArea = styled.textarea`
   font-size: 16px;
   resize: vertical;
   background-color: ${COLORS.bg};
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+
+  &:focus {
+    outline: none;
+    border-color: ${COLORS.sig};
+  }
 `;
 
 const ButtonContainer = styled.div`


### PR DESCRIPTION
# 수정 내용
1. 기능 추가
- WritePost 모달 추가
- PostDetail 페이지 추가
- DevBoard 페이지 추가
- NavigationBar 컴포넌트 추가
- App.jsx에 게시판 이동 및 게시글 상세 페이지 관련 라우트 추가

2. 스타일 개선
- WritePost 컴포넌트의 입력 필드 및 텍스트 영역에 그림자 및 포커스 스타일 추가
- PostDetail 페이지의 그림자 및 텍스트 스타일 수정
- DevBoard 페이지의 PaginationWrapper 그림자 수정 및 더미 데이터 관련 주석 추가
- NavigationBar 컴포넌트의 그림자 및 텍스트 스타일 개선

3. 환경 설정
- colors.js 파일에 배경 색상(연보라) 추가

# 수정한 다른 사람 파일
- app.jsx
- color.jsx


# 참고 사항
- 데이터가 없어서 컴포넌트 안에 더미 데이터를 넣음
   -> 백엔드에서 (더미) 데이터 넘겨주면 관련 로직 등 수정할 계획
- 각자 페이지에 네비게이션바 추가하려면 
   상단에  
   `import NavigationBar from "../../components/layout/NavigationBar";  `
   추가하고. 
   컴포넌트 함수 리턴 내용 제일 상단에 
  ` <NavigationBar />`
   추가.


