### PR TITLE
[feat][style] 컨퍼런스 페이지 컴포넌트 스타일 수정 및 기능 추가

### DIFF
--- a/front/index.html
+++ b/front/index.html
@@ -5,6 +5,10 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
+    <script
+      type="text/javascript"
+      src="https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=y7j6jmrg5c&submodules=geocoder"
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/front/public/data/conferences.json
+++ b/front/public/data/conferences.json
@@ -1,0 +1,76 @@
+{
+  "conferences": [
+    {
+      "id": 1,
+      "title": "우아한형제들 기술이사 김민태의 데브캠프",
+      "category": ["온라인", "유료", "프론트엔드"],
+      "organizer": "패스트캠퍼스",
+      "registration_period": {
+        "start_date": "2024-10-23",
+        "end_date": "2024-12-01"
+      },
+      "description": "우아한형제들 기술이사가 전하는 프론트엔드 최신 트렌드와 실전 경험을 공유합니다.",
+      "website": "https://fastcampus.co.kr/devcamp2024"
+    },
+    {
+      "id": 2,
+      "title": "Next.js 실전 컨퍼런스",
+      "category": ["오프라인", "유료", "풀스택"],
+      "organizer": "Next Academy",
+      "registration_period": {
+        "start_date": "2024-11-15",
+        "end_date": "2024-12-10"
+      },
+      "description": "Next.js 기반의 풀스택 개발을 실전에서 활용하기 위한 노하우를 공유하는 컨퍼런스.",
+      "website": "https://nextacademy.io/conference"
+    },
+    {
+      "id": 3,
+      "title": "우아한형제들 기술이사 김민태의 데브캠프",
+      "category": ["온라인", "유료", "프론트엔드"],
+      "organizer": "패스트캠퍼스",
+      "registration_period": {
+        "start_date": "2024-10-23",
+        "end_date": "2024-12-01"
+      },
+      "description": "우아한형제들 기술이사가 전하는 프론트엔드 최신 트렌드와 실전 경험을 공유합니다.",
+      "website": "https://fastcampus.co.kr/devcamp2024"
+    },
+    {
+      "id": 4,
+      "title": "Next.js 실전 컨퍼런스",
+      "category": ["오프라인", "유료", "풀스택"],
+      "organizer": "Next Academy",
+      "registration_period": {
+        "start_date": "2024-11-15",
+        "end_date": "2024-12-10"
+      },
+      "description": "Next.js 기반의 풀스택 개발을 실전에서 활용하기 위한 노하우를 공유하는 컨퍼런스.",
+      "website": "https://nextacademy.io/conference"
+    },
+    {
+      "id": 5,
+      "title": "우아한형제들 기술이사 김민태의 데브캠프",
+      "category": ["온라인", "유료", "프론트엔드"],
+      "organizer": "패스트캠퍼스",
+      "registration_period": {
+        "start_date": "2024-10-23",
+        "end_date": "2024-12-01"
+      },
+      "description": "우아한형제들 기술이사가 전하는 프론트엔드 최신 트렌드와 실전 경험을 공유합니다.",
+      "website": "https://fastcampus.co.kr/devcamp2024"
+    },
+    {
+      "id": 6,
+      "title": "Next.js 실전 컨퍼런스",
+      "category": ["오프라인", "유료", "풀스택"],
+      "organizer": "Next Academy",
+      "registration_period": {
+        "start_date": "2024-11-15",
+        "end_date": "2024-12-10"
+      },
+      "description": "Next.js 기반의 풀스택 개발을 실전에서 활용하기 위한 노하우를 공유하는 컨퍼런스.",
+      "website": "https://nextacademy.io/conference"
+    }
+  ]
+}

--- a/front/public/data/conferences.json
+++ b/front/public/data/conferences.json
@@ -5,6 +5,7 @@
       "title": "우아한형제들 기술이사 김민태의 데브캠프",
       "category": ["온라인", "유료", "프론트엔드"],
       "organizer": "패스트캠퍼스",
+      "location": "서울특별시 강남구 영동대로 513",
       "registration_period": {
         "start_date": "2024-10-23",
         "end_date": "2024-12-01"
@@ -14,9 +15,10 @@
     },
     {
       "id": 2,
-      "title": "Next.js 실전 컨퍼런스",
+      "title": "경기도 판교 Next.js 실전 컨퍼런스",
       "category": ["오프라인", "유료", "풀스택"],
       "organizer": "Next Academy",
+      "location": "경기도 판교",
       "registration_period": {
         "start_date": "2024-11-15",
         "end_date": "2024-12-10"
@@ -26,9 +28,10 @@
     },
     {
       "id": 3,
-      "title": "우아한형제들 기술이사 김민태의 데브캠프",
+      "title": "인천 송도 우아한형제들 기술이사 김민태의 데브캠프",
       "category": ["온라인", "유료", "프론트엔드"],
       "organizer": "패스트캠퍼스",
+      "location": "인천 송도",
       "registration_period": {
         "start_date": "2024-10-23",
         "end_date": "2024-12-01"
@@ -38,9 +41,10 @@
     },
     {
       "id": 4,
-      "title": "Next.js 실전 컨퍼런스",
+      "title": "서울 역삼 Next.js 실전 컨퍼런스",
       "category": ["오프라인", "유료", "풀스택"],
       "organizer": "Next Academy",
+      "location": "서울 역삼",
       "registration_period": {
         "start_date": "2024-11-15",
         "end_date": "2024-12-10"
@@ -50,9 +54,10 @@
     },
     {
       "id": 5,
-      "title": "우아한형제들 기술이사 김민태의 데브캠프",
+      "title": "코엑스 우아한형제들 기술이사 김민태의 데브캠프",
       "category": ["온라인", "유료", "프론트엔드"],
       "organizer": "패스트캠퍼스",
+      "location": "코엑스",
       "registration_period": {
         "start_date": "2024-10-23",
         "end_date": "2024-12-01"
@@ -62,9 +67,23 @@
     },
     {
       "id": 6,
-      "title": "Next.js 실전 컨퍼런스",
+      "title": "서울 강남 Next.js 실전 컨퍼런스",
       "category": ["오프라인", "유료", "풀스택"],
       "organizer": "Next Academy",
+      "location": "서울 강남",
+      "registration_period": {
+        "start_date": "2024-11-15",
+        "end_date": "2024-12-10"
+      },
+      "description": "Next.js 기반의 풀스택 개발을 실전에서 활용하기 위한 노하우를 공유하는 컨퍼런스.",
+      "website": "https://nextacademy.io/conference"
+    },
+    {
+      "id": 7,
+      "title": "경기 성남 Next.js 실전 컨퍼런스",
+      "category": ["오프라인", "유료", "풀스택"],
+      "organizer": "Next Academy",
+      "location": "경기 성남",
       "registration_period": {
         "start_date": "2024-11-15",
         "end_date": "2024-12-10"

--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Home from './pages/Home/Home';
 import DevBoard from './pages/DevBoard/DevBoard';
 import PostDetail from './pages/DevBoard/PostDetail';
+import DevConf from './pages/DevConf/DevConf';
 
 
 function App() {
@@ -13,6 +14,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/dev-board" element={<DevBoard />} />
         <Route path="/dev-board/:postId" element={<PostDetail />} />
+        <Route path="/dev-conf" element={<DevConf />} />
       </Routes>
     </Router>
   )

--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -5,11 +5,13 @@ import Home from './pages/Home/Home';
 import DevBoard from './pages/DevBoard/DevBoard';
 import PostDetail from './pages/DevBoard/PostDetail';
 import DevConf from './pages/DevConf/DevConf';
+import NavigationBar from './components/layout/NavigationBar';
 
 
 function App() {
   return (
     <Router>
+      <NavigationBar />
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/dev-board" element={<DevBoard />} />

--- a/front/src/components/layout/NavigationBar.jsx
+++ b/front/src/components/layout/NavigationBar.jsx
@@ -86,7 +86,7 @@ export default function NavigationBar() {
                 <MenuButton isActive={location.pathname === "/"} onClick={() => navigate("/")}>
                     <div>메인 화면</div>
                 </MenuButton>
-                <MenuButton isActive={location.pathname === "/conference"} onClick={() => navigate("/conference")}>
+                <MenuButton isActive={location.pathname === "/dev-conf"} onClick={() => navigate("/dev-conf")}>
                     <div>컨퍼런스 일정</div>
                 </MenuButton> 
                 <MenuButton isActive={location.pathname === "/dev-board"} onClick={() => navigate("/dev-board")}>

--- a/front/src/pages/DevConf/ConferenceCard.jsx
+++ b/front/src/pages/DevConf/ConferenceCard.jsx
@@ -1,0 +1,109 @@
+import React from "react";
+import styled from "styled-components";
+
+const Card = styled.div`
+  background: #f9f9ff;
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  padding: 20px;
+  width: 300px;
+  position: relative;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  cursor: pointer;
+
+  &:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 6px 10px rgba(0, 0, 0, 0.15);
+  }
+`;
+
+const ImageContainer = styled.div`
+  background: #f4f4fc;
+  border-radius: 8px;
+  height: 150px;
+  margin-bottom: 15px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+`;
+
+const RandomImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: blur(4px); /* 이미지 흐림 효과 */
+  transition: filter 0.3s ease;
+`;
+
+const Title = styled.h3`
+  font-size: 1.2rem;
+  color: #3a3a5a;
+  margin: 10px 0;
+  font-weight: bold;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+
+const Description = styled.p`
+  font-size: 0.9rem;
+  color: #6b6b85;
+  margin-bottom: 10px;
+`;
+
+const Tags = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+`;
+
+const Tag = styled.span`
+  background: #e9e9f5;
+  color: #6b6b85;
+  font-size: 0.8rem;
+  padding: 5px 10px;
+  border-radius: 20px;
+`;
+
+const LearnMore = styled.a`
+  font-size: 0.9rem;
+  color: #6b5efb;
+  text-decoration: none;
+  display: inline-block;
+  margin-top: 10px;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const StarIcon = styled.div`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  font-size: 1.5rem;
+  color: #6b5efb;
+`;
+
+export default function ConferenceCard({ conference, onClick }) {
+  const randomImageUrl = `https://picsum.photos/seed/${conference.id}/300/150`;
+  console.log(randomImageUrl);
+  return (
+    <Card onClick={onClick}>
+      <ImageContainer>
+        <RandomImage src={randomImageUrl} alt="Random Developer" />
+      </ImageContainer>
+      <Title>{conference.title}</Title>
+      <Description>일정 상세</Description>
+      <Tags>
+        {conference.category.map((tag, index) => (
+          <Tag key={index}>{tag}</Tag>
+        ))}
+      </Tags>
+      <LearnMore href="#">Learn more →</LearnMore>
+      <StarIcon>★</StarIcon>
+    </Card>
+  );
+};

--- a/front/src/pages/DevConf/ConferenceModal.jsx
+++ b/front/src/pages/DevConf/ConferenceModal.jsx
@@ -1,0 +1,72 @@
+import React from "react";
+import styled from "styled-components";
+
+const Backdrop = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+`;
+
+const ModalContent = styled.div`
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  text-align: center;
+  position: relative;
+  max-width: 500px;
+  width: 90%;
+`;
+
+const CloseButton = styled.button`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+`;
+
+const ModalTitle = styled.h2`
+  margin: 0;
+`;
+
+const ModalDetails = styled.p`
+  font-size: 1rem;
+  color: #555;
+`;
+
+const WebsiteLink = styled.a`
+  display: block;
+  margin-top: 10px;
+  color: #6200ea;
+  text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+export default function ConferenceModal ({ conference, onClose }) {
+  return (
+    <Backdrop onClick={onClose}>
+      <ModalContent onClick={(e) => e.stopPropagation()}>
+        <CloseButton onClick={onClose}>×</CloseButton>
+        <ModalTitle>{conference.title}</ModalTitle>
+        <p>{conference.description}</p>
+        <p>
+          등록 기간: {conference.registration_period.start_date} ~ {conference.registration_period.end_date}
+        </p>
+        <WebsiteLink href={conference.website} target="_blank" rel="noopener noreferrer">
+          공식 웹사이트로 이동 →
+        </WebsiteLink>
+      </ModalContent>
+    </Backdrop>
+  );
+};

--- a/front/src/pages/DevConf/DevConf.jsx
+++ b/front/src/pages/DevConf/DevConf.jsx
@@ -1,0 +1,148 @@
+import React, { useState, useEffect } from "react";
+import styled from "styled-components";
+import ConferenceCard from "./ConferenceCard";
+import ConferenceModal from "./ConferenceModal";
+
+const AppContainer = styled.div`
+  text-align: center;
+  padding: 20px;
+`;
+
+const Title = styled.h1`
+  font-size: 2rem;
+  color: #5d5a88;
+  font-weight: bold;
+  margin-bottom: 10px;
+`;
+
+const ControlsContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+  max-width: 1200px;
+  margin: 0 auto;
+`;
+
+const SortButton = styled.button`
+  background: none;
+  border: none;
+  color: #6b6b85;
+  font-size: 1rem;
+  cursor: pointer;
+
+  &:hover {
+    color: #4a4a5a;
+  }
+`;
+
+const ToggleContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: #6b6b85;
+  font-size: 1rem;
+  cursor: pointer; /* 클릭 가능하도록 설정 */
+`;
+
+const ToggleSwitch = styled.div`
+  position: relative;
+  width: 40px;
+  height: 20px;
+  border-radius: 20px;
+  background-color: ${(props) => (props.active ? "#6b5efb" : "#ccc")};
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+
+  &:after {
+    content: "";
+    position: absolute;
+    top: 2px;
+    left: ${(props) => (props.active ? "20px" : "2px")};
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: white;
+    transition: left 0.3s ease;
+  }
+`;
+
+const CardGrid = styled.div`
+  max-width: 1200px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  padding: 20px;
+  place-items: center;
+  margin: 0 auto;
+`;
+
+export default function DevConf() {
+  const [conferences, setConferences] = useState([]);
+  const [selectedConference, setSelectedConference] = useState(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [sortOrder, setSortOrder] = useState("최신순");
+  const [onlineOnly, setOnlineOnly] = useState(false);
+
+  const toggleSortOrder = () => {
+    setSortOrder((prev) => (prev === "최신순" ? "인기순" : "최신순"));
+  };
+
+  const toggleOnlineOnly = () => {
+    setOnlineOnly((prev) => !prev);
+  };
+
+  useEffect(() => {
+    fetch("/data/conferences.json")
+      .then((response) => response.json())
+      .then((data) => setConferences(data.conferences))
+      .catch((error) => console.error("Error loading data:", error));
+  }, []);
+
+  const openModal = (conference) => {
+    setSelectedConference(conference);
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setSelectedConference(null);
+    setIsModalOpen(false);
+  };
+
+  // 데이터 필터링 및 정렬
+  const filteredAndSortedConferences = conferences
+    .filter((conf) => !onlineOnly || conf.category.includes("온라인"))
+    .sort((a, b) => {
+      if (sortOrder === "최신순") {
+        return new Date(b.registration_period.start_date) - new Date(a.registration_period.start_date);
+      } else {
+        return b.popularity - a.popularity; // 인기순 정렬
+      }
+    });
+
+  return (
+    <AppContainer>
+      <Title>컨퍼런스 일정 모아보기</Title>
+
+      <ControlsContainer>
+        <SortButton onClick={toggleSortOrder}>
+        {sortOrder}
+        </SortButton>
+        <ToggleContainer onClick={toggleOnlineOnly}>
+          <span>온라인 행사만 보기</span>
+          <ToggleSwitch active={onlineOnly} />
+        </ToggleContainer>
+      </ControlsContainer>
+
+      <CardGrid>
+        {filteredAndSortedConferences.map((conf) => (
+          <ConferenceCard key={conf.id} conference={conf} onClick={() => openModal(conf)} />
+        ))}
+      </CardGrid>
+
+      {isModalOpen && (
+        <ConferenceModal conference={selectedConference} onClose={closeModal} />
+      )}
+    </AppContainer>
+  );
+};

--- a/front/src/pages/DevConf/DevConf.jsx
+++ b/front/src/pages/DevConf/DevConf.jsx
@@ -6,6 +6,7 @@ import ConferenceModal from "./ConferenceModal";
 const AppContainer = styled.div`
   text-align: center;
   padding: 20px;
+  margin-top: 100px;
 `;
 
 const Title = styled.h1`

--- a/front/src/pages/Home/Home.jsx
+++ b/front/src/pages/Home/Home.jsx
@@ -11,16 +11,78 @@ export default function Home() {
       <Header>
         <h1>DevConf</h1>
         <p>개발자 컨퍼런스 모아보기</p>
-        <MyPageButton onClick={() => navigate("/mypage")}>My Page →</MyPageButton>
+        <MyPageButton onClick={() => navigate("/mypage")}>
+          My Page →
+        </MyPageButton>
       </Header>
       <MainContent>
-        <Card variant="schedule" onClick={() => navigate("/conf")}>
-          <Icon>📅</Icon>
+        <Card variant="schedule" onClick={() => navigate("/dev-conf")}>
+          <Icon>
+            <svg
+              width="130"
+              height="142"
+              viewBox="0 0 130 142"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M111.944 27.5933H18.0555C14.0668 27.5933 10.8333 31.123 10.8333 35.4771V122.199C10.8333 126.553 14.0668 130.083 18.0555 130.083H111.944C115.933 130.083 119.167 126.553 119.167 122.199V35.4771C119.167 31.123 115.933 27.5933 111.944 27.5933Z"
+                stroke="white"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M10.8333 59.1285H119.167"
+                stroke="white"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M39.7205 39.419V11.8257"
+                stroke="white"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M90.2795 39.419V11.8257"
+                stroke="white"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </Icon>
           <CardTitle>개발자 컨퍼런스</CardTitle>
           <CardDescription>일정 모아보기</CardDescription>
         </Card>
         <Card variant="board" onClick={() => navigate("/dev-board")}>
-          <Icon>✏️</Icon>
+          <Icon>
+            <svg
+              width="130"
+              height="130"
+              viewBox="0 0 130 130"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M68.2246 75.2865L50.3528 77.843L52.9045 59.9664L98.8647 14.0063C100.896 11.9747 103.652 10.8334 106.525 10.8334C109.398 10.8334 112.153 11.9747 114.185 14.0063C116.216 16.0378 117.358 18.7932 117.358 21.6663C117.358 24.5394 116.216 27.2947 114.185 29.3263L68.2246 75.2865Z"
+                stroke="#5D5A88"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M99.3052 75.8353V111.945C99.3052 113.86 98.5443 115.697 97.1899 117.051C95.8356 118.406 93.9986 119.167 92.0833 119.167H19.8643C17.9489 119.167 16.112 118.406 14.7577 117.051C13.4033 115.697 12.6424 113.86 12.6424 111.945V39.7259C12.6424 37.8105 13.4033 35.9736 14.7577 34.6192C16.112 33.2648 17.9489 32.504 19.8643 32.504H55.9738"
+                stroke="#5D5A88"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </Icon>
           <CardTitle>개발자 이모저모</CardTitle>
           <CardDescription>게시판</CardDescription>
         </Card>

--- a/front/src/pages/Home/Home.jsx
+++ b/front/src/pages/Home/Home.jsx
@@ -94,6 +94,7 @@ export default function Home() {
 const AppContainer = styled.div`
   text-align: center;
   padding: 20px;
+  margin-top: 100px;
 `;
 
 const Header = styled.header`


### PR DESCRIPTION
# 수정 내용
## 메인 페이지
- SVG 아이콘 추가
## 컨퍼런스 일정 페이지
- 최신순, 인기순 정렬
- 온라인 행사만 보기 toggle 버튼
- 카드 컴포넌트
![image](https://github.com/user-attachments/assets/d1cea7df-5ce4-4b19-a831-f16fc6336126)
  - 이미지 랜덤 생성
  - 정보 미리 보기
- 모달 컴포넌트
![image](https://github.com/user-attachments/assets/0fcb3161-78e9-4868-a49d-191f81d57c67)
  - Naver Map API
# 수정한 공용 파일
- app.jsx
- NavigationBar.jsx
- Home.jsx
# 참고 사항
- Dummy data를 JSON -> object 로 변경하는 것을 미리 구현하기 위해 public 폴더에 생성함
- Navigation Bar를 App.jsx 에 추가
- 페이지의 `margin-top: 200px` 는 너무 커서 `100px` 로 변경
# 고민 사항
- 위시리스트 추가는 미리보기 카드가 아닌 모달 페이지에서 구현하는 것이 스타일 적, 기능 적으로 깔끔한 것 같음